### PR TITLE
refactor: centralize input normalization

### DIFF
--- a/workflows/OQlecQ9yvPUhl6ZL.json
+++ b/workflows/OQlecQ9yvPUhl6ZL.json
@@ -266,32 +266,17 @@
     },
     {
       "parameters": {
-        "assignments": {
-          "assignments": [
-            {
-              "id": "3c2fa4f9-079c-4729-9737-66ce8f42029f",
-              "name": "message",
-              "type": "string",
-              "value": "={{ $json.message }}"
-            },
-            {
-              "id": "b6e57068-8ece-4725-b07d-1b00069943b0",
-              "name": "chat_id",
-              "type": "string",
-              "value": "={{ $json.chat_id }}"
-            }
-          ]
-        },
+        "workflowId": "Y6uBXrtNCR9EuhIH",
         "options": {}
       },
       "id": "0b55c686-11cc-490d-8dc1-bf3193f895eb",
       "name": "Normalize input",
-      "type": "n8n-nodes-base.set",
+      "type": "n8n-nodes-base.executeWorkflow",
       "position": [
         1216,
         320
       ],
-      "typeVersion": 3.4
+      "typeVersion": 1
     },
     {
       "parameters": {
@@ -498,26 +483,17 @@
     },
     {
       "parameters": {
-        "assignments": {
-          "assignments": [
-            {
-              "id": "3910fd43-ebb8-4336-a388-d8fc57c3dc2f",
-              "name": "context",
-              "value": "={{ $json.context }}",
-              "type": "string"
-            }
-          ]
-        },
+        "workflowId": "Y6uBXrtNCR9EuhIH",
         "options": {}
       },
       "id": "a4e1f88e-d8bd-4f1b-830b-50ef328bf230",
       "name": "Normalize input1",
-      "type": "n8n-nodes-base.set",
+      "type": "n8n-nodes-base.executeWorkflow",
       "position": [
         1216,
         -144
       ],
-      "typeVersion": 3.4,
+      "typeVersion": 1,
       "alwaysOutputData": true
     },
     {

--- a/workflows/normalize_input_helper.json
+++ b/workflows/normalize_input_helper.json
@@ -1,0 +1,69 @@
+{
+  "id": "Y6uBXrtNCR9EuhIH",
+  "name": "Normalize Input Helper",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "ba41744b-3949-4963-b952-bd6e7648e0d1",
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        240,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "3c2fa4f9-079c-4729-9737-66ce8f42029f",
+              "name": "message",
+              "value": "={{ $json.message }}",
+              "type": "string"
+            },
+            {
+              "id": "b6e57068-8ece-4725-b07d-1b00069943b0",
+              "name": "chat_id",
+              "value": "={{ $json.chat_id }}",
+              "type": "string"
+            },
+            {
+              "id": "3910fd43-ebb8-4336-a388-d8fc57c3dc2f",
+              "name": "context",
+              "value": "={{ $json.context }}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "aace6eb8-97c1-4a60-82b8-f43aa7d98ded",
+      "name": "Set Normalized",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        460,
+        300
+      ]
+    }
+  ],
+  "connections": {
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Set Normalized",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {},
+  "pinData": {},
+  "tags": []
+}


### PR DESCRIPTION
## Summary
- extract shared normalization into helper subworkflow
- reuse helper via Execute Workflow in both Normalize input nodes

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e92867f483258aea8fd78e3e24f1